### PR TITLE
Add extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ require("neotest").setup({
 })
 ```
 
+If you wish to give additional arguments to the `cargo nextest`,
+you can specify the args when initializing the adapter.
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-rust") {
+        args = { "--no-capture" },
+    }
+  }
+})
+```
+
 Supports standard library tests, [`rstest`](https://github.com/la10736/rstest),
 Tokio's `[#tokio::test]`, and more. Does not support `rstest`'s parametrized
 tests.

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -444,4 +444,27 @@ describe("build_spec", function()
         assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data")
         assert.matches(".+ %-%-test testsuite ", spec.command)
     end)
+
+    it("can add args for command", function()
+        local adapter = require("neotest-rust")({
+            args = {
+                "--no-capture",
+                "--test-threads",
+                3,
+            },
+        })
+        local tree = Tree:new({
+            type = "test",
+            path = vim.loop.cwd() .. "/tests/data/tests/test_it.rs",
+            id = "top_level_math",
+        }, {}, function(data)
+            return data
+        end, {})
+
+        local spec = adapter.build_spec({ tree = tree })
+        assert.matches(
+            "cargo nextest run %-%-no%-fail%-fast %-%-config%-file %g+ %-%-profile neotest %-%-no%-capture %-%-test%-threads 3 %-%-test test_it ",
+            spec.command
+        )
+    end)
 end)


### PR DESCRIPTION
Additional arguments can be set to the test command when initializing the adapter.
This is based on the `neotest-go` and `neotest-python` implementations.

e.g.
```lua
require "neotest-rust" {
  args = { "--no-capture" },
}
```

If `extra_args` is specified when `require('neotest').run.run()` is run, it is concatenated with `args`.