### PR TITLE
Fix treesitter query

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -82,10 +82,10 @@ function adapter.discover_positions(path)
 (
   (attribute_item
     [
-      (meta_item
+      (attribute
         (identifier) @macro_name
       )
-      (attr_item
+      (attribute
         [
 	  (identifier) @macro_name
 	  (scoped_identifier


### PR DESCRIPTION
According to this commit in tree-sitter-rust tree-sitter/tree-sitter-rust@3ddebf46e6fe5e27fa03dc07a829a766b9979c8d they renamed `meta_item` and `attr_item` to `attribute`.
I am pretty clueless when it comes to treesitter queries but this change makes all the tests pass and seem to work in general from quick manual testing.