### PR TITLE
Fix breaking changes in Neotest XML library

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -20,7 +20,7 @@ local is_callable = function(obj)
 end
 
 function adapter.is_test_file(file_path)
-    return vim.endswith(file_path, ".rs")
+    return vim.endswith(file_path, ".rs") and #adapter.discover_positions(file_path):to_list() ~= 1
 end
 
 local function is_unit_test(path)

--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -5,7 +5,6 @@ local open = context_manager.open
 local Path = require("plenary.path")
 local with = context_manager.with
 local xml = require("neotest.lib.xml")
-local xml_tree = require("neotest.lib.xml.tree")
 
 local adapter = { name = "neotest-rust" }
 
@@ -188,17 +187,15 @@ function adapter.results(spec, result, tree)
         data = reader:read("*a")
     end)
 
-    local handler = xml_tree()
-    local parser = xml.parser(handler)
-    parser:parse(data)
+    local root = xml.parse(data)
 
     local results = {}
 
     local testsuites
-    if #handler.root.testsuites.testsuite == 0 then
-        testsuites = {handler.root.testsuites.testsuite}
+    if #root.testsuites.testsuite == 0 then
+        testsuites = {root.testsuites.testsuite}
     else
-        testsuites = handler.root.testsuites.testsuite
+        testsuites = root.testsuites.testsuite
     end
     for _, testsuite in pairs(testsuites) do
         local testcases

--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -192,25 +192,32 @@ function adapter.results(spec, result, tree)
     local parser = xml.parser(handler)
     parser:parse(data)
 
-    local testcases
-    if #handler.root.testsuites.testsuite.testcase == 0 then
-        testcases = { handler.root.testsuites.testsuite.testcase }
-    else
-        testcases = handler.root.testsuites.testsuite.testcase
-    end
-
     local results = {}
 
-    for _, testcase in pairs(testcases) do
-        if testcase.failure then
-            results[testcase._attr.name] = {
-                status = "failed",
-                short = testcase.failure[1],
-            }
+    local testsuites
+    if #handler.root.testsuites.testsuite == 0 then
+        testsuites = {handler.root.testsuites.testsuite}
+    else
+        testsuites = handler.root.testsuites.testsuite
+    end
+    for _, testsuite in pairs(testsuites) do
+        local testcases
+        if #testsuite.testcase == 0 then
+            testcases = { testsuite.testcase }
         else
-            results[testcase._attr.name] = {
-                status = "passed",
-            }
+            testcases = testsuite.testcase
+        end
+        for _, testcase in pairs(testcases) do
+            if testcase.failure then
+                results[testcase._attr.name] = {
+                    status = "failed",
+                    short = testcase.failure[1],
+                }
+            else
+                results[testcase._attr.name] = {
+                    status = "passed",
+                }
+            end
         end
     end
 

--- a/tests/data/multiple_test_suites.xml
+++ b/tests/data/multiple_test_suites.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="4" failures="2" errors="0" uuid="148332a3-772e-45ec-be48-0cd9be5afd62" timestamp="2022-12-16T12:05:30.587+00:00" time="0.002">
+    <testsuite name="tmp::bin/tmp" tests="2" disabled="0" errors="0" failures="1">
+        <testcase name="foo::tests::should_fail" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:30.587+00:00" time="0.001">
+            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
+            <system-out>
+running 1 test
+test foo::tests::should_fail ... FAILED
+
+failures:
+
+failures:
+    foo::tests::should_fail
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+</system-out>
+            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+</system-err>
+        </testcase>
+        <testcase name="foo::tests::should_pass" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:30.588+00:00" time="0.001">
+        </testcase>
+    </testsuite>
+    <testsuite name="tmp::tests" tests="2" disabled="0" errors="0" failures="1">
+        <testcase name="should_fail" classname="tmp::tests" timestamp="2022-12-16T12:05:30.587+00:00" time="0.001">
+            <failure type="test failure">thread &apos;should_fail&apos; panicked at &apos;assertion failed: false&apos;, tests/tests.rs:8:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
+            <system-out>
+running 1 test
+test should_fail ... FAILED
+
+failures:
+
+failures:
+    should_fail
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+</system-out>
+            <system-err>thread &apos;should_fail&apos; panicked at &apos;assertion failed: false&apos;, tests/tests.rs:8:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+</system-err>
+        </testcase>
+        <testcase name="should_pass" classname="tmp::tests" timestamp="2022-12-16T12:05:30.587+00:00" time="0.002">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/data/single_test_suite.xml
+++ b/tests/data/single_test_suite.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="2" failures="1" errors="0" uuid="17fb0f4a-f4d2-40b2-b229-ba30aac4b211" timestamp="2022-12-16T12:05:54.600+00:00" time="0.002">
+    <testsuite name="tmp::bin/tmp" tests="2" disabled="0" errors="0" failures="1">
+        <testcase name="foo::tests::should_pass" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:54.600+00:00" time="0.001">
+        </testcase>
+        <testcase name="foo::tests::should_fail" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:54.600+00:00" time="0.002">
+            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
+            <system-out>
+running 1 test
+test foo::tests::should_fail ... FAILED
+
+failures:
+
+failures:
+    foo::tests::should_fail
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
+
+</system-out>
+            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+</system-err>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/data/src/mymod/notests.rs
+++ b/tests/data/src/mymod/notests.rs
@@ -1,0 +1,5 @@
+mod notests;
+
+fn main() {
+    println!("Hello world!")
+}

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -3,15 +3,15 @@ local plugin = require("neotest-rust")
 local Tree = require("neotest.types").Tree
 
 describe("is_test_file", function()
-    it("matches Rust files with tests in them", function()
+    async.it("matches Rust files with tests in them", function()
         assert.equals(true, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/src/mymod/foo.rs"))
     end)
 
-    it("doesn't discover non-Rust files", function()
+    async.it("doesn't discover non-Rust files", function()
         assert.equals(false, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/Cargo.toml"))
     end)
 
-    it("doesn't discover Rust file without tests in it", function()
+    async.it("doesn't discover Rust file without tests in it", function()
         assert.equals(false, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/src/mymod/notests.rs"))
     end)
 end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -476,3 +476,55 @@ describe("build_spec", function()
         )
     end)
 end)
+
+describe("build_spec", function()
+    it("parses results with a single test suite in it", function()
+        local adapter = require("neotest-rust")({})
+        local path = vim.loop.cwd() .. "/tests/data/single_test_suite.xml"
+        local spec = {context = {junit_path = path}}
+
+        local results = adapter.results(spec, nil, nil)
+
+        local expected = {
+            ["foo::tests::should_fail"] = {
+                short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                status = "failed",
+            },
+            ["foo::tests::should_pass"] = {
+                status = "passed",
+            },
+        }
+        print(vim.inspect(results))
+
+        assert.are.same(expected, results)
+    end)
+
+    it("parses results with a multiple test suites in it", function()
+        local adapter = require("neotest-rust")({})
+        local path = vim.loop.cwd() .. "/tests/data/multiple_test_suites.xml"
+        local spec = {context = {junit_path = path}}
+
+        local results = adapter.results(spec, nil, nil)
+        print(vim.inspect(results))
+
+        local expected = {
+            ["foo::tests::should_fail"] = {
+                short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                status = "failed",
+            },
+            ["foo::tests::should_pass"] = {
+                status = "passed",
+            },
+            should_fail = {
+                short = "thread 'should_fail' panicked at 'assertion failed: false', tests/tests.rs:8:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                status = "failed",
+            },
+            should_pass = {
+                status = "passed",
+            },
+        }
+        print(vim.inspect(expected))
+
+        assert.are.same(expected, results)
+    end)
+end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -481,7 +481,7 @@ describe("build_spec", function()
     it("parses results with a single test suite in it", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/tests/data/single_test_suite.xml"
-        local spec = {context = {junit_path = path}}
+        local spec = { context = { junit_path = path } }
 
         local results = adapter.results(spec, nil, nil)
 
@@ -502,7 +502,7 @@ describe("build_spec", function()
     it("parses results with a multiple test suites in it", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/tests/data/multiple_test_suites.xml"
-        local spec = {context = {junit_path = path}}
+        local spec = { context = { junit_path = path } }
 
         local results = adapter.results(spec, nil, nil)
         print(vim.inspect(results))

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -494,7 +494,6 @@ describe("build_spec", function()
                 status = "passed",
             },
         }
-        print(vim.inspect(results))
 
         assert.are.same(expected, results)
     end)
@@ -523,7 +522,6 @@ describe("build_spec", function()
                 status = "passed",
             },
         }
-        print(vim.inspect(expected))
 
         assert.are.same(expected, results)
     end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -3,8 +3,16 @@ local plugin = require("neotest-rust")
 local Tree = require("neotest.types").Tree
 
 describe("is_test_file", function()
-    it("matches Rust files", function()
-        assert.equals(true, plugin.is_test_file("foo.rs"))
+    it("matches Rust files with tests in them", function()
+        assert.equals(true, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/src/mymod/foo.rs"))
+    end)
+
+    it("doesn't discover non-Rust files", function()
+        assert.equals(false, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/Cargo.toml"))
+    end)
+
+    it("doesn't discover Rust file without tests in it", function()
+        assert.equals(false, plugin.is_test_file(vim.loop.cwd() .. "/tests/data/src/mymod/notests.rs"))
     end)
 end)
 


### PR DESCRIPTION
Thanks for the plugin

I noticed today that I couldn't run my tests anymore since there's been a breaking change in Neotest's XML parsing library. Thought I'd give back by making the fix. 

There's some other changes of mine in there to handle multiple test suites and filter out src files from the list of test files if there are no tests. Feel free to drop those.
