### PR TITLE
fix: correct quotes around junit_path #20

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -132,7 +132,7 @@ function adapter.build_spec(args)
     end
 
     with(open(tmp_nextest_config, "a"), function(writer)
-        writer:write('[profile.neotest.junit]\npath = "' .. junit_path .. '"')
+        writer:write("[profile.neotest.junit]\npath = '" .. junit_path .. "'")
     end)
 
     local command = vim.tbl_flatten({


### PR DESCRIPTION
I would have tried my hand at adding a test for this, but I am inexperienced with lua and couldn't get `make test` to run even with an unmodified codebase (some docs on contributing to the repo would help smooth this process):

```﻿﻿﻿
neotest-rust on  main via 🌙
❯ make test
nvim --headless -u tests/minimal_init.vim -c "TSInstallSync rust | quit"
Error detected while processing /Users/nerdo/personal/settings/nvim/after/plugin/nvim-colorizer.lua:
&termguicolors must be setrust parser already available: would you like to reinstall ? y/n: rust parser already available: would you like to reinstall ? y/n: n
n

^[^Cmake: *** [deps/nvim-treesitter/parser/rust.so] Interrupt: 2


neotest-rust on  main via 🌙 took 59s
```