### PR TITLE
Match test functions with flexible macro order

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -125,12 +125,17 @@ function adapter.discover_positions(path)
         ]
       )
     ]
-  )+
+  )
+  (attribute_item
+    (attribute
+      (identifier)
+    )
+  )*
   .
   (function_item
     name: (identifier) @test.name
   ) @test.definition
-  (#contains? @macro_name "test" "rstest" "case")
+  (#any-of? @macro_name "test" "rstest" "case")
 
 )
 (mod_item name: (identifier) @namespace.name)? @namespace.definition

--- a/tests/data/simple-package/src/mymod/multiple_macros.rs
+++ b/tests/data/simple-package/src/mymod/multiple_macros.rs
@@ -1,0 +1,15 @@
+#[test]
+#[should_panic]
+fn should_panic_last() {
+    assert_eq!(1, 1);
+}
+
+#[should_panic]
+#[test]
+fn should_panic_first() {
+    assert_eq!(1, 1);
+}
+
+fn no_macros() {
+    assert_eq!(2, 1);
+}

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -296,6 +296,42 @@ describe("discover_positions", function()
 
         assert.are.same(positions, expected_positions)
     end)
+
+    async.it("discovers positions when there are multiple macros present", function()
+        local positions = plugin
+            .discover_positions(vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/multiple_macros.rs")
+            :to_list()
+
+        local expected_positions = {
+            {
+                id = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/multiple_macros.rs",
+                name = "multiple_macros.rs",
+                path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/multiple_macros.rs",
+                range = { 0, 0, 15, 0 },
+                type = "file",
+            },
+            {
+                {
+                    id = "mymod::multiple_macros::should_panic_last",
+                    name = "should_panic_last",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/multiple_macros.rs",
+                    range = { 2, 0, 4, 1 },
+                    type = "test",
+                },
+            },
+            {
+                {
+                    id = "mymod::multiple_macros::should_panic_first",
+                    name = "should_panic_first",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/multiple_macros.rs",
+                    range = { 8, 0, 10, 1 },
+                    type = "test",
+                },
+            },
+        }
+
+        assert.are.same(positions, expected_positions)
+    end)
 end)
 
 describe("build_spec", function()


### PR DESCRIPTION
Previously, the query was only able to match test functions if the desired macros were placed immediately before the function definition, without any other macros in between. The updated query now correctly matches test functions that have the target macro attribute, regardless of the order of other macros.

Closes #29 