### PR TITLE
Add check in init.lua to prevent nil access

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -250,11 +250,14 @@ function adapter.results(spec, result, tree)
         local root = xml.parse(data)
 
         local testsuites
-        if #root.testsuites.testsuite == 0 then
+        if not root.testsuites.testsuite == nil and #root.testsuites.testsuite == 0 then
             testsuites = { root.testsuites.testsuite }
         else
             testsuites = root.testsuites.testsuite
         end
+	if testsuites == nil then
+	    return results
+	end
         for _, testsuite in pairs(testsuites) do
             local testcases
             if #testsuite.testcase == 0 then

--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -255,9 +255,9 @@ function adapter.results(spec, result, tree)
         else
             testsuites = root.testsuites.testsuite
         end
-	if testsuites == nil then
-	    return results
-	end
+        if testsuites == nil then
+            return results
+        end
         for _, testsuite in pairs(testsuites) do
             local testcases
             if #testsuite.testcase == 0 then


### PR DESCRIPTION
Currently, this is cause the plugin to crash (https://github.com/rouge8/neotest-rust/issues/32) when running any test.