### PR TITLE
add support for debugging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,29 @@ Supports standard library tests, [`rstest`](https://github.com/la10736/rstest),
 Tokio's `[#tokio::test]`, and more. Does not support `rstest`'s parametrized
 tests.
 
+## Debugging Tests
+
+Codelldb is the default adapter used for debugging.
+Alternatives can be specified via the `dap_adapter` property during initialization.
+
+```lua
+require("neotest").setup({
+  adapters = {
+    require("neotest-rust") {
+        args = { "--no-capture" },
+        dap_adapter = "lldb",
+    }
+  }
+})
+```
+
+See [nvim-dap](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation),
+and [rust-tools#debugging](https://github.com/simrat39/rust-tools.nvim/wiki/Debugging) if you are using rust-tools.nvim,
+for more information.
+
 ## Limitations
+
+The following limitations apply to both running and debugging tests.
 
 - Assumes unit tests in `main.rs`, `mod.rs`, and `lib.rs` are in a `tests`
   module.
@@ -40,3 +62,5 @@ tests.
   `tests/testsuite/main.rs`), all tests in that subdirectory will be run (e.g.
   all tests in `tests/testsuite/`). This is because Cargo lacks the capability
   to specify a test file.
+
+Additionally, when debugging tests, no output from failed tests will be captured in the results provided to Neotest.

--- a/lua/neotest-rust/dap.lua
+++ b/lua/neotest-rust/dap.lua
@@ -1,0 +1,172 @@
+local lib = require("neotest.lib")
+local sep = require("plenary.path").path.sep
+local util = require("neotest-rust.util")
+
+local M = {}
+
+--
+--{
+--  "target": {
+--    "src_path": "/home/mark/workspace/Lua/neotest-rust/tests/data/src/lib.rs",
+--  },
+--  "executable": "/home/mark/workspace/Lua/neotest-rust/tests/data/target/debug/deps/data-<>",
+--}
+--
+-- Return a table containing each 'src_path' => 'executable' listed by
+-- 'cargo test --message-format=JSON' (see sample output above).
+local function get_src_paths(root)
+    local src_paths = {}
+    local src_filter = '"src_path":"(.+' .. sep .. '.+.rs)",'
+    local exe_filter = '"executable":"(.+' .. sep .. "deps" .. sep .. '.+)",'
+
+    local cmd = {
+        "cargo",
+        "test",
+        "--manifest-path=" .. root .. sep .. "Cargo.toml",
+        "--message-format=JSON",
+        "--no-run",
+        "--quiet",
+    }
+    local handle = assert(io.popen(table.concat(cmd, " ")))
+    local line = handle:read("l")
+
+    while line do
+        if string.find(line, src_filter) and string.find(line, exe_filter) then
+            local src_path = string.match(line, src_filter)
+            local executable = string.match(line, exe_filter)
+            src_paths[src_path] = executable
+        end
+        line = handle:read("l")
+    end
+
+    if handle then
+        handle:close()
+    end
+
+    return src_paths
+end
+
+local function collect(query, source, root)
+    local mods = {}
+
+    for _, match in query:iter_matches(root, source) do
+        local captured_nodes = {}
+        for i, capture in ipairs(query.captures) do
+            captured_nodes[capture] = match[i]
+        end
+
+        if captured_nodes["mod_name"] then
+            local mod_name = vim.treesitter.get_node_text(captured_nodes["mod_name"], source)
+            table.insert(mods, mod_name)
+        end
+    end
+
+    return mods
+end
+
+-- Get the list of <mod_name>s imported via '(pub) mod <mod_name>;'
+local function get_mods(path)
+    local content = lib.files.read(path)
+    local query = [[
+(mod_item
+	name: (identifier) @mod_name
+	.
+)
+    ]]
+
+    local root, lang = lib.treesitter.get_parse_root(path, content, {})
+    local parsed_query = lib.treesitter.normalise_query(lang, query)
+
+    return collect(parsed_query, content, root)
+end
+
+-- Determine if mod is in <mod_name>.rs or <mod_name>/mod.rs
+local function construct_mod_path(src_path, mod_name)
+    local match_str = "(.-)[^\\/]-%.?(%w+)%.?[^\\/]*$"
+    local abs_path, _ = string.match(src_path, match_str)
+
+    local mod_file = abs_path .. mod_name .. ".rs"
+    local mod_dir = abs_path .. mod_name .. sep .. "mod.rs"
+
+    if util.file_exists(mod_file) then
+        return mod_file
+    elseif util.file_exists(mod_dir) then
+        return mod_dir
+    end
+
+    return nil
+end
+
+-- Recursive search for 'path' amongst all modules declared in 'src_path'
+local function search_modules(src_path, path)
+    local mods = get_mods(src_path)
+
+    for _, mod in ipairs(mods) do
+        local mod_path = construct_mod_path(src_path, mod)
+        if path == mod_path then
+            return true
+        elseif search_modules(mod_path, path) then
+            return true
+        end
+    end
+
+    return false
+end
+
+-- Debugging is only possible from the generated test binary
+-- See: https://github.com/rust-lang/cargo/issues/1924#issuecomment-289764090
+-- Identify the binary containing the tests defined in 'path'
+M.get_test_binary = function(root, path)
+    local src_paths = get_src_paths(root)
+
+    -- If 'path' is the source of the binary we are done
+    for src_path, executable in pairs(src_paths) do
+        if path == src_path then
+            return executable
+        end
+    end
+
+    -- Otherwise we need to figure out which 'src_path' it is loaded from
+    for src_path, executable in pairs(src_paths) do
+        local mod_match = search_modules(src_path, path)
+        if mod_match then
+            return executable
+        end
+    end
+
+    return nil
+end
+
+-- Translate plain test output to a neotest results object
+M.translate_results = function(output_path)
+    local result_map = {
+        ok = "passed",
+        FAILED = "failed",
+        ignored = "skipped",
+    }
+
+    local results = {}
+
+    local handle = assert(io.open(output_path))
+    local line = handle:read("l")
+
+    while line do
+        if string.find(line, "^test result:") then
+            --
+        elseif string.find(line, "^test .+ %.%.%. %w+") then
+            local test_name, cargo_result = string.match(line, "^test (.+) %.%.%. (%w+)")
+
+            results[test_name] = { status = assert(result_map[cargo_result]) }
+        end
+
+        line = handle:read("l")
+    end
+
+    if handle then
+        handle:close()
+    end
+
+    return results
+end
+
+return M

--- a/lua/neotest-rust/util.lua
+++ b/lua/neotest-rust/util.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+M.file_exists = function(file)
+    local f = io.open(file, "r")
+
+    if f ~= nil then
+        io.close(f)
+        return true
+    else
+        return false
+    end
+end
+
+return M

--- a/tests/dap_spec.lua
+++ b/tests/dap_spec.lua
@@ -1,0 +1,147 @@
+local async = require("nio.tests")
+local strings = require("plenary.strings")
+local dap = require("neotest-rust.dap")
+
+describe("get_test_binary", function()
+    -- Binaries are created for src/lib.rs, src/main.rs, tests/test_it.rs, and
+    -- tests/testsuite/main.rs. We can only test that they match expected substrings
+    -- and that the other modules resolve to their source binaries
+    describe("for a simple-package", function()
+        local cwd = vim.loop.cwd()
+        local root = cwd .. "/tests/data/simple-package"
+
+        local lib_actual = dap.get_test_binary(root, root .. "/src/lib.rs")
+        local main_actual = dap.get_test_binary(root, root .. "/src/main.rs")
+        local test_it_actual = dap.get_test_binary(root, root .. "/tests/test_it.rs")
+        local testsuite_actual = dap.get_test_binary(root, root .. "/tests/testsuite/main.rs")
+
+        async.it("returns the test binary for src/lib.rs", function()
+            assert(lib_actual)
+            local expected = root .. "/target/debug/deps/simple_package-"
+            local actual = strings.truncate(lib_actual, lib_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for src/main.rs", function()
+            assert(main_actual)
+            local expected = root .. "/target/debug/deps/simple_package-"
+            local actual = strings.truncate(main_actual, main_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for src/mymod/foo.rs", function()
+            local expected = main_actual
+            local actual = dap.get_test_binary(root, root .. "/src/mymod/foo.rs")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for src/mymod/mod.rs", function()
+            local expected = main_actual
+            local actual = dap.get_test_binary(root, root .. "/src/mymod/mod.rs")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for src/mymod/notests.rs", function()
+            local expected = nil
+            local actual = dap.get_test_binary(root, root .. "/src/mymod/notests.rs")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for tests/test_it.rs", function()
+            assert(test_it_actual)
+            local expected = root .. "/target/debug/deps/test_it-"
+            local actual = strings.truncate(test_it_actual, test_it_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for tests/testsuite/it.rs", function()
+            local expected = testsuite_actual
+            local actual = dap.get_test_binary(root, root .. "/tests/testsuite/it.rs")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for tests/testsuite/main.rs", function()
+            assert(testsuite_actual)
+            local expected = root .. "/target/debug/deps/testsuite-"
+            local actual = strings.truncate(testsuite_actual, testsuite_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+    end)
+
+    describe("for a workspace", function()
+        local cwd = vim.loop.cwd()
+        local root = cwd .. "/tests/data/workspace"
+
+        async.it("returns the test binary for with_unit_tests/src/main.rs", function()
+            local with_unit_actual = dap.get_test_binary(root, root .. "/with_unit_tests/src/main.rs")
+            assert(with_unit_actual)
+
+            local expected = root .. "/target/debug/deps/with_unit_tests-"
+            local actual = strings.truncate(with_unit_actual, with_unit_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for with_integration_tests/src/main.rs", function()
+            local with_integration_main_actual =
+                dap.get_test_binary(root, root .. "/with_integration_tests/src/main.rs")
+            assert(with_integration_main_actual)
+
+            local expected = root .. "/target/debug/deps/with_integration_tests-"
+            local actual = strings.truncate(with_integration_main_actual, with_integration_main_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for with_integration_tests/tests/it.rs", function()
+            local with_integration_it_actual = dap.get_test_binary(root, root .. "/with_integration_tests/tests/it.rs")
+            assert(with_integration_it_actual)
+
+            local expected = root .. "/target/debug/deps/it-"
+            local actual = strings.truncate(with_integration_it_actual, with_integration_it_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+    end)
+end)
+
+describe("translate_results", function()
+    async.it("parses results with a single test suite in it", function()
+        local path = vim.loop.cwd() .. "/tests/data/simple-package/1"
+
+        local results = dap.translate_results(path)
+
+        local expected = {
+            ["tests::math"] = { status = "passed" },
+        }
+
+        assert.are.same(expected, results)
+    end)
+
+    async.it("translates raw results with multiple test suites in it", function()
+        local path = vim.loop.cwd() .. "/tests/data/simple-package/3"
+
+        local results = dap.translate_results(path)
+
+        local expected = {
+
+            ["tests::math"] = { status = "passed" },
+
+            ["mymod::tests::math"] = { status = "passed" },
+            ["mymod::foo::tests::math"] = { status = "passed" },
+            ["tests::nested::nested_math"] = { status = "passed" },
+            ["tests::basic_math"] = { status = "skipped" },
+            ["tests::failed_math"] = { status = "failed" },
+        }
+
+        assert.are.same(expected, results)
+    end)
+end)

--- a/tests/data/simple-package/1
+++ b/tests/data/simple-package/1
@@ -1,0 +1,5 @@
+
+running 1 test
+test tests::math ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

--- a/tests/data/simple-package/3
+++ b/tests/data/simple-package/3
@@ -1,0 +1,27 @@
+
+running 1 test
+test tests::math ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+
+running 5 tests
+test tests::basic_math ... ignored
+test mymod::foo::tests::math ... ok
+test mymod::tests::math ... ok
+test tests::nested::nested_math ... ok
+test tests::failed_math ... FAILED
+
+failures:
+
+---- tests::failed_math stdout ----
+thread 'tests::failed_math' panicked at 'assertion failed: `(left == right)`
+  left: `2`,
+ right: `3`', src/main.rs:16:9
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    tests::failed_math
+
+test result: FAILED. 3 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.00s

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -579,15 +579,283 @@ describe("build_spec", function()
             assert.matches(".+ %-%-test it", spec.command)
         end)
     end)
+
+    describe("debug adapter protocol", function()
+        describe("for a simple-package", function()
+            async.it("can debug a single test", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/foo.rs",
+                    id = "mymod::foo::tests::math",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "mymod::foo::tests::math",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug a test file", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/foo.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/foo.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "mymod::foo",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug tests in main.rs", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/main.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/main.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug tests in lib.rs", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/lib.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/lib.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug tests in mod.rs", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/mod.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/mymod/mod.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "mymod",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug a single integration test", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/test_it.rs",
+                    id = "top_level_math",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "top_level_math",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug a file of integration tests", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/test_it.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/tests/test_it.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug an integration test in main.rs in a subdirectory", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/testsuite/main.rs",
+                    id = "testsuite_top_level_math",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "testsuite_top_level_math",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug all integration tests in main.rs in a subdirectory", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/testsuite/main.rs",
+                    id = vim.loop.cwd() .. "/tests/data/simple-package/src/tests/testsuite/main.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug an integration test in another test file in a subdirectory", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/testsuite/it.rs",
+                    id = "it::testsuite_it_math",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "it::testsuite_it_math",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+
+            async.it("can debug all integration tests in another test file in a subdirectory", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/simple-package/tests/testsuite/it.rs",
+                    id = "it::",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "it",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/simple-package")
+            end)
+        end)
+
+        describe("for a workspace", function()
+            it("can debug a single test", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/workspace/with_unit_tests/src/main.rs",
+                    id = "test_it",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "test_it",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/workspace")
+            end)
+
+            it("can debug a test file", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/workspace/with_unit_tests/src/main.rs",
+                    id = vim.loop.cwd() .. "/tests/data/workspace/with_unit_tests/src/main.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/workspace")
+            end)
+
+            it("can debug a single integration test", function()
+                local tree = Tree:new({
+                    type = "test",
+                    path = vim.loop.cwd() .. "/tests/data/workspace/with_integration_tests/tests/it.rs",
+                    id = "it_works",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "--exact",
+                    "it_works",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/workspace")
+            end)
+
+            it("can debug a file of integration tests", function()
+                local tree = Tree:new({
+                    type = "file",
+                    path = vim.loop.cwd() .. "/tests/data/workspace/with_integration_tests/tests/it.rs",
+                    id = vim.loop.cwd() .. "/tests/data/workspace/with_integration_tests/tests/it.rs",
+                }, {}, function(data)
+                    return data
+                end, {})
+
+                local spec = plugin.build_spec({ tree = tree, strategy = "dap" })
+                assert.are.same(spec.strategy.args, {
+                    "--nocapture",
+                    "tests",
+                })
+                assert.equal(spec.cwd, vim.loop.cwd() .. "/tests/data/workspace")
+            end)
+        end)
+    end)
 end)
 
 describe("results", function()
     it("parses results with a single test suite in it", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/tests/data/simple-package/single_test_suite.xml"
-        local spec = { context = { junit_path = path } }
+        local spec = { context = { junit_path = path }, strategy = { stdio = nil } }
+        local strategy_result = { code = 101, output = "/some/path" }
 
-        local results = adapter.results(spec, nil, nil)
+        local results = adapter.results(spec, strategy_result, nil)
 
         local expected = {
             ["foo::tests::should_fail"] = {
@@ -605,9 +873,10 @@ describe("results", function()
     it("parses results with a multiple test suites in it", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/tests/data/simple-package/multiple_test_suites.xml"
-        local spec = { context = { junit_path = path } }
+        local spec = { context = { junit_path = path }, strategy = { stdio = nil } }
+        local strategy_result = { code = 101, output = "/some/path" }
 
-        local results = adapter.results(spec, nil, nil)
+        local results = adapter.results(spec, strategy_result, nil)
 
         local expected = {
             ["foo::tests::should_fail"] = {
@@ -629,11 +898,63 @@ describe("results", function()
         assert.are.same(expected, results)
     end)
 
+    it("parses raw results from result.output after debugging", function()
+        local adapter = require("neotest-rust")({})
+        local path = vim.loop.cwd() .. "/tests/data/simple-package/does-not-exist.xml"
+        local spec = { context = { junit_path = path, strategy = "dap" }, strategy = { stdio = nil } }
+        local strategy_result = { code = 101, output = vim.loop.cwd() .. "/tests/data/simple-package/1" }
+
+        local results = adapter.results(spec, strategy_result, nil)
+
+        local expected = {
+            ["tests::math"] = {
+                status = "passed",
+            },
+        }
+
+        assert.are.same(expected, results)
+    end)
+
+    it("parses raw results from strategy.stdio after debugging with codelldb", function()
+        local adapter = require("neotest-rust")({})
+        local path = vim.loop.cwd() .. "/tests/data/simple-package/does-not-exist.xml"
+        local spec = {
+            context = { junit_path = path, strategy = "dap" },
+            strategy = { stdio = { nil, vim.loop.cwd() .. "/tests/data/simple-package/3" } },
+        }
+        local strategy_result = { code = 101, output = vim.loop.cwd() .. "/tests/data/simple-package/1" }
+
+        local results = adapter.results(spec, strategy_result, nil)
+
+        local expected = {
+            ["tests::math"] = {
+                status = "passed",
+            },
+            ["tests::basic_math"] = {
+                status = "skipped",
+            },
+            ["mymod::foo::tests::math"] = {
+                status = "passed",
+            },
+            ["mymod::tests::math"] = {
+                status = "passed",
+            },
+            ["tests::nested::nested_math"] = {
+                status = "passed",
+            },
+            ["tests::failed_math"] = {
+                status = "failed",
+            },
+        }
+
+        assert.are.same(expected, results)
+    end)
+
     it("returns the cargo-nextest output if there is no junit file", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/does-not-exist.xml"
         local position_id = "some_test"
-        local spec = { context = { junit_path = path, position_id = position_id } }
+        local spec = { context = { junit_path = path, position_id = position_id }, strategy = { stdio = nil } }
         local strategy_result = { code = 101, output = "/some/path" }
 
         local results = adapter.results(spec, strategy_result, nil)

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,0 +1,22 @@
+local async = require("nio.tests")
+local util = require("neotest-rust.util")
+
+describe("file_exists", function()
+    local cwd = vim.loop.cwd()
+
+    async.it("returns true when the file exists", function()
+        local path = cwd .. "/tests/data/simple-package/src/mymod/foo.rs"
+
+        local exists = util.file_exists(path)
+
+        assert.equal(exists, true)
+    end)
+
+    async.it("returns false when the file does not exist", function()
+        local path = cwd .. "/tests/data/src/simple-package/mymod/bar.rs"
+
+        local exists = util.file_exists(path)
+
+        assert.equal(exists, false)
+    end)
+end)


### PR DESCRIPTION
Support for debugging is enabled by modifying the build_spec() and results() functions in init.lua. Additional functionality is provided via the dap.lua module.

In order to build the necessary spec for debugging, the name of the binary that executes the target test or test file must be determined. This is achieved with dap.get_test_binary().

Since output from the binaries cannot be converted to junit xml, an auxillary function, dap.translate_results(), is used to convert the standard rust test output into the result object expected by neotest.

This change will also move the file_exists() function into a dedicated util.lua module.

This change has been tested with codelldb and lldb-vscode. Other adapters may or may not require additional updates for compatibility. Debugging is subject to the same limitations as listed in the README regarding running tests. Additionally, only the status of the test is captured when debugging.