### PR TITLE
Add support for alternate binaries

### DIFF
--- a/tests/dap_spec.lua
+++ b/tests/dap_spec.lua
@@ -12,6 +12,7 @@ describe("get_test_binary", function()
 
         local lib_actual = dap.get_test_binary(root, root .. "/src/lib.rs")
         local main_actual = dap.get_test_binary(root, root .. "/src/main.rs")
+        local alt_bin_actual = dap.get_test_binary(root, root .. "/src/bin/alt-bin.rs")
         local test_it_actual = dap.get_test_binary(root, root .. "/tests/test_it.rs")
         local testsuite_actual = dap.get_test_binary(root, root .. "/tests/testsuite/main.rs")
 
@@ -27,6 +28,14 @@ describe("get_test_binary", function()
             assert(main_actual)
             local expected = root .. "/target/debug/deps/simple_package-"
             local actual = strings.truncate(main_actual, main_actual:len() - 16, "-")
+
+            assert.equal(expected, actual)
+        end)
+
+        async.it("returns the test binary for src/bin/alt-bin.rs", function()
+            assert(alt_bin_actual)
+            local expected = root .. "/target/debug/deps/alt_bin-"
+            local actual = strings.truncate(alt_bin_actual, alt_bin_actual:len() - 16, "-")
 
             assert.equal(expected, actual)
         end)

--- a/tests/data/simple-package/src/bin/alt-bin.rs
+++ b/tests/data/simple-package/src/bin/alt-bin.rs
@@ -1,0 +1,11 @@
+fn main() {
+    println!("Hello, world!");
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_alt_bin() {
+        assert_eq!(4 % 2, 0);
+    }
+}


### PR DESCRIPTION
Cargo has support for multiple binaries/executables per package. They can be placed in `src/bin/*.rs` and can be referenced in the cargo commands by adding a `--bin` flag.

This PR adds supports for those binaries.

P.S.
I should note that it's also possible to add additional binaries by specifying them in `Cargo.toml`. This PR does not include that, but we might want to consider either supporting that or adding a note to the README.