### PR TITLE
Neotest diagnostics

### DIFF
--- a/lua/neotest-rust/errors.lua
+++ b/lua/neotest-rust/errors.lua
@@ -6,6 +6,11 @@ local M = {}
 function M.parse_errors(output)
     local message, line = output:match("thread '[^']+' panicked at '([^']+)', [^:]+:(%d+):%d+")
 
+    -- If we can't parse the output, return an empty table
+    if message == nil then
+        return {}
+    end
+
     -- Note: we have to return the line index, not the line number
     return {
         { line = tonumber(line) - 1, message = message },

--- a/lua/neotest-rust/errors.lua
+++ b/lua/neotest-rust/errors.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+--- Parse errors from rustc output
+---@param output string
+---@return neotest.Error[]
+function M.parse_errors(output)
+    local message, line = output:match("thread '[^']+' panicked at '([^']+)', [^:]+:(%d+):%d+")
+
+    -- Note: we have to return the line index, not the line number
+    return {
+        { line = tonumber(line) - 1, message = message },
+    }
+end
+
+return M

--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -408,6 +408,7 @@ function adapter.results(spec, result, tree)
         results[spec.context.position_id] = {
             status = "failed",
             output = output,
+            errors = { { message = "test error message" } },
         }
     end
 

--- a/tests/errors_spec.lua
+++ b/tests/errors_spec.lua
@@ -1,6 +1,13 @@
 local errors = require("neotest-rust.errors")
 
 describe("parses errors from output", function()
+    it("non-parsable errors in output", function()
+        local output = "something\nwent\nwrong"
+        local results = errors.parse_errors(output)
+
+        assert.is_true(#results == 0)
+    end)
+
     it("assert_eq", function()
         local output = "test tests::failed_math ... FAILED\n"
             .. "failures:\n\n"

--- a/tests/errors_spec.lua
+++ b/tests/errors_spec.lua
@@ -1,0 +1,23 @@
+local errors = require("neotest-rust.errors")
+
+describe("parses errors from output", function()
+    it("assert_eq", function()
+        local output = "test tests::failed_math ... FAILED\n"
+            .. "failures:\n\n"
+            .. "---- tests::failed_math stdout ----\n"
+            .. "thread 'tests::failed_math' panicked at 'assertion failed: `(left == right)`\n"
+            .. "  left: `2`,\n"
+            .. " right: `3`', src/main.rs:16:9\n"
+            .. "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+
+        local results = errors.parse_errors(output)
+        local expected = {
+            {
+                line = 15,
+                message = "assertion failed: `(left == right)`\n  left: `2`,\n right: `3`",
+            },
+        }
+
+        assert.are.same(expected, results)
+    end)
+end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -971,7 +971,7 @@ describe("results", function()
                 status = "failed",
                 errors = {
                     {
-                        line = 10,
+                        line = 9,
                         message = "assertion failed: false",
                     },
                 },
@@ -996,7 +996,7 @@ describe("results", function()
             ["foo::tests::should_fail"] = {
                 short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
-                errors = { { line = 10, message = "assertion failed: false" } },
+                errors = { { line = 9, message = "assertion failed: false" } },
             },
             ["foo::tests::should_pass"] = {
                 status = "passed",
@@ -1004,7 +1004,7 @@ describe("results", function()
             should_fail = {
                 short = "thread 'should_fail' panicked at 'assertion failed: false', tests/tests.rs:8:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
-                errors = { { line = 8, message = "assertion failed: false" } },
+                errors = { { line = 7, message = "assertion failed: false" } },
             },
             should_pass = {
                 status = "passed",
@@ -1083,28 +1083,5 @@ describe("results", function()
         }
 
         assert.are.same(expected, results)
-    end)
-
-    describe("parses errors from output", function()
-        it("assert_eq", function()
-            local adapter = require("neotest-rust")({})
-            local output = "test tests::failed_math ... FAILED\n"
-                .. "failures:\n\n"
-                .. "---- tests::failed_math stdout ----\n"
-                .. "thread 'tests::failed_math' panicked at 'assertion failed: `(left == right)`\n"
-                .. "  left: `2`,\n"
-                .. " right: `3`', src/main.rs:16:9\n"
-                .. "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
-
-            local results = adapter.parse_errors(output)
-            local expected = {
-                {
-                    line = 16,
-                    message = "assertion failed: `(left == right)`\n  left: `2`,\n right: `3`",
-                },
-            }
-
-            assert.are.same(expected, results)
-        end)
     end)
 end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -969,6 +969,12 @@ describe("results", function()
             ["foo::tests::should_fail"] = {
                 short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
+                errors = {
+                    {
+                        line = 10,
+                        message = "assertion failed: false",
+                    },
+                },
             },
             ["foo::tests::should_pass"] = {
                 status = "passed",
@@ -990,6 +996,7 @@ describe("results", function()
             ["foo::tests::should_fail"] = {
                 short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
+                errors = { { line = 10, message = "assertion failed: false" } },
             },
             ["foo::tests::should_pass"] = {
                 status = "passed",
@@ -997,6 +1004,7 @@ describe("results", function()
             should_fail = {
                 short = "thread 'should_fail' panicked at 'assertion failed: false', tests/tests.rs:8:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
+                errors = { { line = 8, message = "assertion failed: false" } },
             },
             should_pass = {
                 status = "passed",
@@ -1075,5 +1083,28 @@ describe("results", function()
         }
 
         assert.are.same(expected, results)
+    end)
+
+    describe("parses errors from output", function()
+        it("assert_eq", function()
+            local adapter = require("neotest-rust")({})
+            local output = "test tests::failed_math ... FAILED\n"
+                .. "failures:\n\n"
+                .. "---- tests::failed_math stdout ----\n"
+                .. "thread 'tests::failed_math' panicked at 'assertion failed: `(left == right)`\n"
+                .. "  left: `2`,\n"
+                .. " right: `3`', src/main.rs:16:9\n"
+                .. "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
+
+            local results = adapter.parse_errors(output)
+            local expected = {
+                {
+                    line = 16,
+                    message = "assertion failed: `(left == right)`\n  left: `2`,\n right: `3`",
+                },
+            }
+
+            assert.are.same(expected, results)
+        end)
     end)
 end)


### PR DESCRIPTION
![image](https://github.com/rouge8/neotest-rust/assets/9047770/9fee0d41-53b1-4480-9d45-2c27d2026070)

resolves #22 

For now, I parse rustc panic messages and display the whole message as a diagnostic.
I could imagine that we may want to handle specialised cases for common assert failed messages, like for example: [assert_eq](https://doc.rust-lang.org/beta/src/core/panicking.rs.html#269) could become a compact diagnostic message in vim: ``` left: `2`, right: `3` ```, but we could add that in another PR (if wanted), thoughts? @rouge8 @igorlfs
