### PR TITLE
check for nil testsuite when parsing test results

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -359,7 +359,9 @@ function adapter.results(spec, result, tree)
         local root = xml.parse(data)
 
         local testsuites
-        if #root.testsuites.testsuite == 0 then
+        if root.testsuites.testsuite == nil then
+            testsuites = {}
+        elseif #root.testsuites.testsuite == 0 then
             testsuites = { root.testsuites.testsuite }
         else
             testsuites = root.testsuites.testsuite

--- a/tests/data/simple-package/no_test_suite.xml
+++ b/tests/data/simple-package/no_test_suite.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="2" failures="1" errors="0" uuid="17fb0f4a-f4d2-40b2-b229-ba30aac4b211" timestamp="2022-12-16T12:05:54.600+00:00" time="0.002">
+</testsuites>

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -999,6 +999,19 @@ describe("results", function()
         assert.are.same(expected, results)
     end)
 
+    it("parses results with no test suite in it", function()
+        local adapter = require("neotest-rust")({})
+        local path = vim.loop.cwd() .. "/tests/data/simple-package/no_test_suite.xml"
+        local spec = { context = { junit_path = path }, strategy = { stdio = nil } }
+        local strategy_result = { code = 101, output = "/some/path" }
+
+        local results = adapter.results(spec, strategy_result, nil)
+
+        local expected = {}
+
+        assert.are.same(expected, results)
+    end)
+
     it("parses results with empty system-out and system-err", function()
         local adapter = require("neotest-rust")({})
         local path = vim.loop.cwd() .. "/tests/data/simple-package/test_failure_with_empty_stdout_stder.xml"


### PR DESCRIPTION
If a project has no tests and neotrest tries to run tests, no tests are found.
If a project has tests, and the tests are removed, and then neotest tries to run tests, it gets the following error:

```
neotest-rust: ~/.local/share/nvim/lazy/neotest/lua/nio/init.lua:105: The coroutine failed with this message:                                                                 
...l/share/nvim/lazy/neotest-rust/lua/neotest-rust/init.lua:362: attempt to get length of field 'testsuite' (a nil value)                                                              
stack traceback:                                                                                                                                                                       
        ...l/share/nvim/lazy/neotest-rust/lua/neotest-rust/init.lua: in function 'results'                                                                                             
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:131: in function '_run_spec'                                                                                       
        ...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:89: in function <...al/share/nvim/lazy/neotest/lua/neotest/client/runner.lua:88>  
```

this fixes #32 and adds unit test to the change in #33