### PR TITLE
fix(errors): handle diagnotics from latest version of nextest

### DIFF
--- a/lua/neotest-rust/errors.lua
+++ b/lua/neotest-rust/errors.lua
@@ -8,7 +8,7 @@ function M.parse_errors(output)
         return {}
     end
 
-    local message, line = output:match("thread '[^']+' panicked at '([^']+)', [^:]+:(%d+):%d+")
+    local line, message = output:match("thread '[^']+' panicked at [^:]+:(%d+):%d+:\n(.*)note:.*")
 
     -- If we can't parse the output, return an empty table
     if message == nil then

--- a/tests/data/simple-package/multiple_test_suites.xml
+++ b/tests/data/simple-package/multiple_test_suites.xml
@@ -2,7 +2,8 @@
 <testsuites name="nextest-run" tests="4" failures="2" errors="0" uuid="148332a3-772e-45ec-be48-0cd9be5afd62" timestamp="2022-12-16T12:05:30.587+00:00" time="0.002">
     <testsuite name="tmp::bin/tmp" tests="2" disabled="0" errors="0" failures="1">
         <testcase name="foo::tests::should_fail" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:30.587+00:00" time="0.001">
-            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at src/foo.rs:10:9:
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
             <system-out>
 running 1 test
@@ -16,7 +17,8 @@ failures:
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
 
 </system-out>
-            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at src/foo.rs:10:9:
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 </system-err>
         </testcase>
@@ -25,7 +27,8 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
     </testsuite>
     <testsuite name="tmp::tests" tests="2" disabled="0" errors="0" failures="1">
         <testcase name="should_fail" classname="tmp::tests" timestamp="2022-12-16T12:05:30.587+00:00" time="0.001">
-            <failure type="test failure">thread &apos;should_fail&apos; panicked at &apos;assertion failed: false&apos;, tests/tests.rs:8:5
+            <failure type="test failure">thread &apos;should_fail&apos; panicked at tests/tests.rs:8:5:
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
             <system-out>
 running 1 test
@@ -39,7 +42,8 @@ failures:
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
 
 </system-out>
-            <system-err>thread &apos;should_fail&apos; panicked at &apos;assertion failed: false&apos;, tests/tests.rs:8:5
+            <system-err>thread &apos;should_fail&apos; panicked at tests/tests.rs:8:5
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 </system-err>
         </testcase>

--- a/tests/data/simple-package/single_test_suite.xml
+++ b/tests/data/simple-package/single_test_suite.xml
@@ -4,7 +4,8 @@
         <testcase name="foo::tests::should_pass" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:54.600+00:00" time="0.001">
         </testcase>
         <testcase name="foo::tests::should_fail" classname="tmp::bin/tmp" timestamp="2022-12-16T12:05:54.600+00:00" time="0.002">
-            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+            <failure type="test failure">thread &apos;foo::tests::should_fail&apos; panicked at src/foo.rs:10:9:
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace</failure>
             <system-out>
 running 1 test
@@ -18,7 +19,8 @@ failures:
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s
 
 </system-out>
-            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at &apos;assertion failed: false&apos;, src/foo.rs:10:9
+            <system-err>thread &apos;foo::tests::should_fail&apos; panicked at src/foo.rs:10:9:
+assertion failed: false
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 </system-err>
         </testcase>

--- a/tests/errors_spec.lua
+++ b/tests/errors_spec.lua
@@ -9,19 +9,17 @@ describe("parses errors from output", function()
     end)
 
     it("assert_eq", function()
-        local output = "test tests::failed_math ... FAILED\n"
-            .. "failures:\n\n"
-            .. "---- tests::failed_math stdout ----\n"
-            .. "thread 'tests::failed_math' panicked at 'assertion failed: `(left == right)`\n"
+        local output = "thread 'tests::failed_math' panicked at src/main.rs:16:9:\n"
+            .. "assertion `left == right` failed\n"
             .. "  left: `2`,\n"
-            .. " right: `3`', src/main.rs:16:9\n"
+            .. " right: `3`\n"
             .. "note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"
 
         local results = errors.parse_errors(output)
         local expected = {
             {
                 line = 15,
-                message = "assertion failed: `(left == right)`\n  left: `2`,\n right: `3`",
+                message = "assertion `left == right` failed\n  left: `2`,\n right: `3`\n",
             },
         }
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -982,12 +982,12 @@ describe("results", function()
 
         local expected = {
             ["foo::tests::should_fail"] = {
-                short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                short = "thread 'foo::tests::should_fail' panicked at src/foo.rs:10:9:\nassertion failed: false\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
                 errors = {
                     {
                         line = 9,
-                        message = "assertion failed: false",
+                        message = "assertion failed: false\n",
                     },
                 },
             },
@@ -1040,17 +1040,17 @@ describe("results", function()
 
         local expected = {
             ["foo::tests::should_fail"] = {
-                short = "thread 'foo::tests::should_fail' panicked at 'assertion failed: false', src/foo.rs:10:9\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                short = "thread 'foo::tests::should_fail' panicked at src/foo.rs:10:9:\nassertion failed: false\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
-                errors = { { line = 9, message = "assertion failed: false" } },
+                errors = { { line = 9, message = "assertion failed: false\n" } },
             },
             ["foo::tests::should_pass"] = {
                 status = "passed",
             },
             should_fail = {
-                short = "thread 'should_fail' panicked at 'assertion failed: false', tests/tests.rs:8:5\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
+                short = "thread 'should_fail' panicked at tests/tests.rs:8:5:\nassertion failed: false\nnote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace",
                 status = "failed",
-                errors = { { line = 7, message = "assertion failed: false" } },
+                errors = { { line = 7, message = "assertion failed: false\n" } },
             },
             should_pass = {
                 status = "passed",


### PR DESCRIPTION
Update diagnostic handling to work with the latest versions of nextest. Besides updating the match and the test, I also updated some "build_spec" tests and their respective XMLs (so that the tests are passing; I'm not sure if updating the XMLs directly is a good idea).

I'm not really proficient with Lua patterns, so I've hard-coded the match containing the message to capture all lines up to a line containing 'note' -- that's far from elegant, it'd be nice to at least handle the case where RUST_BACKTRACE is set and a line with 'stack' should be used instead. But still, there must be a better way to do that.

Preview:

![image](https://github.com/rouge8/neotest-rust/assets/84649544/5e5c9388-baf2-4cea-8b02-f182de536d71)

![image](https://github.com/rouge8/neotest-rust/assets/84649544/225cacfc-5a9b-45aa-80b6-72a71fb1899d)
