### PR TITLE
parse unexpected panics

### DIFF
--- a/lua/neotest-rust/errors.lua
+++ b/lua/neotest-rust/errors.lua
@@ -10,6 +10,11 @@ function M.parse_errors(output)
 
     local message, line = output:match("thread '[^']+' panicked at '([^']+)', [^:]+:(%d+):%d+")
 
+    if message == nil then
+        -- Try a different expression
+        _, line, message = output:match("thread '[^']+' panicked at ([^:]+):(%d+):[^:]+:\n([^\n]*)")
+    end
+
     -- If we can't parse the output, return an empty table
     if message == nil then
         return {}

--- a/tests/errors_spec.lua
+++ b/tests/errors_spec.lua
@@ -53,7 +53,7 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
         local results = errors.parse_errors(output)
         local expected = {
             {
-                line = 86,
+                line = 85,
                 message = "called `Result::unwrap()` on an `Err` value: unexpected end of input while parsing min or version number",
             },
         }

--- a/tests/errors_spec.lua
+++ b/tests/errors_spec.lua
@@ -27,4 +27,37 @@ describe("parses errors from output", function()
 
         assert.are.same(expected, results)
     end)
+
+    it("parses unexpected panics", function()
+        local output = [[
+running 1 test
+test rocks::dependency::tests::parse_dependency ... FAILED
+
+failures:
+
+    Finished test [unoptimized + debuginfo] target(s) in 0.12s
+    Starting 1 test across 2 binaries (17 skipped)
+        FAIL [   0.004s] rocks-lib rocks::dependency::tests::parse_dependency
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 17 filtered out; finis
+hed in 0.00s
+
+
+--- STDERR:              rocks-lib rocks::dependency::tests::parse_dependency ---
+thread 'rocks::dependency::tests::parse_dependency' panicked at rocks-lib/src/rocks/dependency.rs:86:64:
+called `Result::unwrap()` on an `Err` value: unexpected end of input while parsing min or version number
+
+Location:
+    rocks-lib/src/rocks/dependency.rs:62:22
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+]]
+        local results = errors.parse_errors(output)
+        local expected = {
+            {
+                line = 86,
+                message = "called `Result::unwrap()` on an `Err` value: unexpected end of input while parsing min or version number",
+            },
+        }
+
+        assert.are.same(expected, results)
+    end)
 end)


### PR DESCRIPTION
Hey :wave: 

When a test panics (not due to an assertion failure - in my case due to an `unwrap` on `Err`), neotest-rust can't parse the output.

So I added another attempt at parsing in case `message == nil`. It's a bit hacky, but seems to work, at least in my case. :sweat_smile: 

I've added a spec in which I copied the test output of my test case that was failing.
Unfortunately, I can't run `make test` locally, because I'm on NixOS and it tries to install the tree-sitter parser to the nix store.
