### PR TITLE
ci: add luarocks workflow

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,24 @@
+---
+name: "Luarocks"
+on:
+  pull_request: # Tests the luarocks package build on PR
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Luarocks upload
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          dependencies: |
+            neotest
+            nvim-treesitter


### PR DESCRIPTION
Hey :wave: 

I noticed this plugin has some dependencies that are on luarocks...

### Summary

This PR is part of a push to get neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

* See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html) by @teto.
* See also: [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.

### Things done:

* Add a workflow that publishes tags to LuaRocks when a tag or release is pushed.

If you'd prefer automated releases, I can update this PR to use a release-please workflow that creates release PRs with SemVer versioning based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/),
based on [this guide](https://github.com/vhyrro/sample-luarocks-plugin) by @vhyrro.

### Notes:

* Tagged releases are installed locally and then published to luarocks.org.
  On PRs, a test release is installed, but not published.
* For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
* Due to a shortcoming in LuaRocks (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the LuaRocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.