### PR TITLE
fix: find project root dir

### DIFF
--- a/lua/neotest-rust/init.lua
+++ b/lua/neotest-rust/init.lua
@@ -41,7 +41,7 @@ function adapter.root(dir)
     local cwd = lib.files.match_root_pattern("Cargo.toml")(dir)
 
     if cwd == nil then
-        return
+        return vim.fs.root(0, "Cargo.toml")
     end
 
     return cargo_metadata(cwd).workspace_root


### PR DESCRIPTION
```
plugin.nvim/
  lua/
  rust-project/'
    Cargo.toml
    test.rs
```

Open neovim under `plugin.nvim`, the plugin failed to find root dir of the rust project.